### PR TITLE
mmc: don't blindly retry on timed-out flushes 1/2

### DIFF
--- a/drivers/mmc/card/block.c
+++ b/drivers/mmc/card/block.c
@@ -1616,7 +1616,8 @@ static int mmc_blk_issue_flush(struct mmc_queue *mq, struct request *req)
 	int ret = 0;
 
 	ret = mmc_flush_cache(card);
-	if (ret == -ETIMEDOUT) {
+	if (ret == -ETIMEDOUT &&
+		(card->quirks & MMC_QUIRK_RETRY_FLUSH_TIMEOUT)) {
 		pr_info("%s: requeue flush request after timeout", __func__);
 		spin_lock_irq(q->queue_lock);
 		blk_requeue_request(q, req);
@@ -3372,6 +3373,8 @@ static const struct mmc_fixup blk_fixups[] =
 	/* Disable cache for this cards */
 	MMC_FIXUP("H8G2d", CID_MANFID_HYNIX, CID_OEMID_ANY, add_quirk_mmc,
 		  MMC_QUIRK_CACHE_DISABLE),
+	MMC_FIXUP(CID_NAME_ANY, CID_MANFID_HYNIX, CID_OEMID_ANY, add_quirk_mmc,
+		  MMC_QUIRK_RETRY_FLUSH_TIMEOUT),
 	END_FIXUP
 };
 


### PR DESCRIPTION
The commit "mmc: block: flush request requeue after timeout"
introduced logic that blindly requeues flush requests that have
timed-out without checking the card state or taking advantage of
any of the error recovery logic in the driver.  This leads to an
infinite loop if the card continues to time out because of how
flush requests are prioritized over other requests.

This commit disables the retry except in the case of Hynix cards.