### PR TITLE
mmc: don't blindly retry on timed-out flushes 2/2

### DIFF
--- a/include/linux/mmc/card.h
+++ b/include/linux/mmc/card.h
@@ -357,6 +357,8 @@ struct mmc_card {
 
 #define MMC_QUIRK_CACHE_DISABLE (1 << 14)       /* prevent cache enable */
 
+#define MMC_QUIRK_RETRY_FLUSH_TIMEOUT (1 << 31) /* requeue flush command timeouts */
+
 	unsigned int		erase_size;	/* erase size in sectors */
  	unsigned int		erase_shift;	/* if erase unit is power 2 */
  	unsigned int		pref_erase;	/* in sectors */


### PR DESCRIPTION
The commit "mmc: block: flush request requeue after timeout"
introduced logic that blindly requeues flush requests that have
timed-out without checking the card state or taking advantage of
any of the error recovery logic in the driver.  This leads to an
infinite loop if the card continues to time out because of how
flush requests are prioritized over other requests.

In this commit:

"#define MMC_QUIRK_RETRY_FLUSH_TIMEOUT (1 << 31) /* requeue flush command timeouts */ "

This commit disables the retry except in the case of Hynix cards.